### PR TITLE
Add dotenv dependency for database seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "connect-pg-simple": "^10.0.0",
     "cookie-parser": "^1.4.7",
     "date-fns": "^3.6.0",
+    "dotenv": "^16.4.5",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",


### PR DESCRIPTION
- Add dotenv ^16.4.5 to package.json dependencies
- Required for environment variable loading in seed.ts
- Resolves 'Cannot find package dotenv' error during installation seeding